### PR TITLE
Fix for a linking error

### DIFF
--- a/imgui/CMakeLists.txt
+++ b/imgui/CMakeLists.txt
@@ -20,6 +20,7 @@ set(IMGUI_SOURCES
     imgui.cpp
     imgui_demo.cpp
     imgui_draw.cpp
+    imgui_widgets.cpp
 )
 
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
When linking against libimgui.a, the linker will complain about many undefined references.
This small change prevents those linking errors.

Here's `make`'s output without the change (environment is MSYS2/MinGW-w64):
```text
$ make
Scanning dependencies of target MagnumImGui
[ 25%] Building CXX object src/CMakeFiles/MagnumImGui.dir/MagnumImGui.cpp.obj
[ 50%] Linking CXX shared library libMagnumImGui.dll
CMakeFiles/MagnumImGui.dir/objects.a(MagnumImGui.cpp.obj):MagnumImGui.cpp:(.text+0x1cec): undefined reference to `ImGui::Image(void*, ImVec2 const&, ImVec2 const&, ImVec2 const&, ImVec4 const&, ImVec4 const&)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x3745): undefined reference to `ImGui::InputText(char const*, char*, unsigned long long, int, int (*)(ImGuiInputTextCallbackData*), void*)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x531a): undefined reference to `ImGuiMenuColumns::ImGuiMenuColumns()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0xd058): undefined reference to `ImGui::ButtonBehavior(ImRect const&, unsigned int, bool*, bool*, int)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0xd2be): undefined reference to `ImGui::ButtonBehavior(ImRect const&, unsigned int, bool*, bool*, int)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0xf9ce): undefined reference to `ImGui::Scrollbar(int)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0xf9e7): undefined reference to `ImGui::Scrollbar(int)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1064f): undefined reference to `ImGuiMenuColumns::Update(int, float, bool)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x107e4): undefined reference to `ImGui::CollapseButton(unsigned int, ImVec2 const&)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x10908): undefined reference to `ImGui::CloseButton(unsigned int, ImVec2 const&, float)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x14843): undefined reference to `ImGui::TextV(char const*, char*)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1a5ac): undefined reference to `ImGui::Selectable(char const*, bool, int, ImVec2 const&)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1b64e): undefined reference to `ImGui::ButtonBehavior(ImRect const&, unsigned int, bool*, bool*, int)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1cdd2): undefined reference to `ImGui::Button(char const*, ImVec2 const&)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ce0d): undefined reference to `ImGui::Button(char const*, ImVec2 const&)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ce48): undefined reference to `ImGui::Button(char const*, ImVec2 const&)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1cea1): undefined reference to `ImGui::SliderInt(char const*, int*, int, int, char const*)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1dd41): undefined reference to `ImGui::TreeNode(void const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ddbf): undefined reference to `ImGui::TextColored(ImVec4 const&, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ddd1): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1df25): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e02a): undefined reference to `ImGui::TreeNode(void const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e405): undefined reference to `ImGui::Selectable(char const*, bool, int, ImVec2 const&)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e495): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e4d3): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e553): undefined reference to `ImGui::TreeNode(char const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e597): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e617): undefined reference to `ImGui::TreeNode(void const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e716): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e831): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e8d5): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e936): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e989): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1e9bb): more undefined references to `ImGui::BulletText(char const*, ...)' follow
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1eb76): undefined reference to `ImGui::TreeNode(char const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ebfa): undefined reference to `ImGui::TreeNode(void const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1eca0): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ed49): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ed57): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ed65): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ed80): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ed85): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ee01): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ee6c): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1eeb0): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1eed5): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1eeed): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ef00): undefined reference to `ImGui::Checkbox(char const*, bool*)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ef13): undefined reference to `ImGui::Checkbox(char const*, bool*)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ef18): undefined reference to `ImGui::Separator()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1ef5c): undefined reference to `ImGui::TreeNode(char const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1efad): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1efcd): undefined reference to `ImGui::TreeNode(char const*, char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f0a1): undefined reference to `ImGui::BulletText(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f0af): undefined reference to `ImGui::TreePop()'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f0bb): undefined reference to `ImGui::TreeNode(char const*)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f130): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f166): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f1d0): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f24e): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f284): undefined reference to `ImGui::Text(char const*, ...)'
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f2ba): more undefined references to `ImGui::Text(char const*, ...)' follow
C:/msys64/mingw64/lib/libimgui.a(imgui.cpp.obj):imgui.cpp:(.text+0x1f434): undefined reference to `ImGui::TreePop()'
collect2.exe: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/MagnumImGui.dir/build.make:91: src/libMagnumImGui.dll] Error 1
make[1]: *** [CMakeFiles/Makefile2:93: src/CMakeFiles/MagnumImGui.dir/all] Error 2
make: *** [Makefile:130: all] Error 2
```